### PR TITLE
Add username-based auth and profile handling

### DIFF
--- a/my-app/frontend/app/home/index.jsx
+++ b/my-app/frontend/app/home/index.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Image, Pressable, ScrollView, Text, TextInput, View } from 'react-native';
 import {homeStyles} from '../../constants/homeStyles';
 import { router } from 'expo-router';
@@ -42,12 +42,42 @@ export default function HomeScreen() {
   const [search, setSearch] = useState('');
   const [notifVisible, setNotifVisible] = useState(false);
   const [streakVisible, setStreakVisible] = useState(false);
+  const [profileUsername, setProfileUsername] = useState(null);
 
-  let user_text = ""
-  if (user !== null && user !== undefined){
-    user_text = user.user_metadata?.display_name || user.email || '<User_Placeholder>'
+  useEffect(() => {
+    if (!user?.id || !supabase) {
+      setProfileUsername(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    (async () => {
+      const { data } = await supabase
+        .from('users')
+        .select('username')
+        .eq('user_id', user.id)
+        .maybeSingle();
+
+      if (!cancelled) {
+        setProfileUsername(data?.username?.trim() || null);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [user?.id]);
+
+  let user_text = '';
+  if (user !== null && user !== undefined) {
+    user_text =
+      profileUsername ||
+      user.user_metadata?.username ||
+      user.email?.split('@')[0] ||
+      '<User_Placeholder>';
   } else {
-    user_text = "<User_Placeholder>"
+    user_text = '<User_Placeholder>';
   }
 
   return (

--- a/my-app/frontend/app/index.jsx
+++ b/my-app/frontend/app/index.jsx
@@ -6,14 +6,14 @@ import { supabase } from '@/lib/supabaseClient';
 import PicnicBackground from '../components/PicnicBackground';
 
 export default function LoginScreen() {
-  const [email, setEmail] = useState('');
+  const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
 
   const handleLogin = async () => {
-    if (!email.trim() || !password.trim()) {
-      setError('Please enter your email and password.');
+    if (!username.trim() || !password.trim()) {
+      setError('Please enter your username and password.');
       return;
     }
 
@@ -25,8 +25,29 @@ export default function LoginScreen() {
     setError('');
     setIsLoading(true);
 
+    const loginUsername = username.trim().toLowerCase();
+
+    const { data: profile, error: profileError } = await supabase
+      .from('users')
+      .select('email')
+      .eq('username', loginUsername)
+      .maybeSingle();
+
+    if (profileError) {
+      setIsLoading(false);
+      setError(profileError.message);
+      return;
+    }
+
+    const emailForAuth = profile?.email?.trim();
+    if (!emailForAuth) {
+      setIsLoading(false);
+      setError('No account found for that username.');
+      return;
+    }
+
     const { error: signInError } = await supabase.auth.signInWithPassword({
-      email: email.trim(),
+      email: emailForAuth,
       password,
     });
 
@@ -53,11 +74,11 @@ export default function LoginScreen() {
               <Text style={styles.title}>LOGIN</Text>
 
               <TextInput
-                value={email}
-                onChangeText={setEmail}
-                placeholder="User"
+                value={username}
+                onChangeText={setUsername}
+                placeholder="Username"
                 autoCapitalize="none"
-                keyboardType="email-address"
+                autoCorrect={false}
                 placeholderTextColor="#888"
                 style={styles.input}
               />

--- a/my-app/frontend/app/register.jsx
+++ b/my-app/frontend/app/register.jsx
@@ -4,6 +4,8 @@ import { router } from 'expo-router';
 import { supabase } from '@/lib/supabaseClient';
 import PicnicBackground from '../components/PicnicBackground';
  
+const USERNAME_REGEX = /^[a-z0-9_]{3,20}$/;
+
 export default function RegisterScreen() {
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
@@ -14,16 +16,25 @@ export default function RegisterScreen() {
   const [isLoading, setIsLoading] = useState(false);
   const [userNameAvailable, setUserNameAvailable] = useState(null);
 
+  const normalizedUsernamePreview = userName.trim().toLowerCase();
+  const usernamePatternOk = USERNAME_REGEX.test(normalizedUsernamePreview);
+
 const checkUserName = async (name) => {
-  if (name.trim().length < 3) {
+  const normalized = name.trim().toLowerCase();
+  if (!USERNAME_REGEX.test(normalized)) {
+    setUserNameAvailable(null);
+    return;
+  }
+
+  if (!supabase) {
     setUserNameAvailable(null);
     return;
   }
 
   const { data } = await supabase
     .from('users')
-    .select('display_name')
-    .eq('display_name', name.trim())
+    .select('username')
+    .eq('username', normalized)
     .maybeSingle();
 
   setUserNameAvailable(!data); // true if no match found
@@ -32,6 +43,22 @@ const checkUserName = async (name) => {
   const handleRegister = async () => {
     if (!email.trim() || !password.trim()) {
       setError('Please enter both email and password.');
+      return;
+    }
+
+    if (!userName.trim()) {
+      setError('Please choose a username.');
+      return;
+    }
+
+    const normalizedUsername = userName.trim().toLowerCase();
+    if (!USERNAME_REGEX.test(normalizedUsername)) {
+      setError('Username must be 3-20 characters: lowercase letters, numbers, or underscores.');
+      return;
+    }
+
+    if (userNameAvailable !== true) {
+      setError('Please choose an available username.');
       return;
     }
 
@@ -48,31 +75,40 @@ const checkUserName = async (name) => {
     setError('');
     setIsLoading(true);
 
+    const displayNameFromName = [firstName.trim(), lastName.trim()].filter(Boolean).join(' ').trim();
+
     const { data, error: signUpError } = await supabase.auth.signUp({
       email: email.trim(),
       password,
+      options: {
+        data: {
+          username: normalizedUsername,
+        },
+      },
     });
 
-    setIsLoading(false);
-
     if (signUpError) {
+      setIsLoading(false);
       setError(signUpError.message);
       return;
     }
 
-    if (!userNameAvailable) {
-        setError('Please choose an available username.');
-          return;
-}
+    if (!data?.user?.id) {
+      setIsLoading(false);
+      setError('Could not create account. Check your email confirmation settings.');
+      return;
+    }
 
     const { error: profileError } = await supabase
-    .from('users')
-    .update({
-      first_name: firstName.trim(),
-      last_name: lastName.trim(),
-      display_name: userName.trim(),
-    })
-    .eq('user_id', data.user.id);
+      .from('users')
+      .update({
+        first_name: firstName.trim(),
+        last_name: lastName.trim(),
+        username: normalizedUsername,
+        ...(displayNameFromName ? { display_name: displayNameFromName } : {}),
+        email: email.trim(),
+      })
+      .eq('user_id', data.user.id);
 
     setIsLoading(false);
 
@@ -118,7 +154,7 @@ const checkUserName = async (name) => {
         placeholderTextColor="#888"
         style={styles.input}
       />
-      {userName.length >= 3 && (
+      {usernamePatternOk && userNameAvailable !== null && (
         <Text style={{ 
           color: userNameAvailable ? 'green' : 'red', 
           alignSelf: 'flex-start',


### PR DESCRIPTION
Switch login flow to use usernames (lookup user email by username before authenticating) and update registration to enforce/normalize usernames. Register: add USERNAME_REGEX, normalize to lowercase, validate availability, include username in signUp metadata, and persist username/display_name/email in the users table. Login: replace email input with username, validate input, query users table for email, then sign in with returned email. Home screen: fetch profile username from users table (with effect + cancellation) and prefer it for display. Also adjust input placeholders, validation messages, and availability indicator logic.

Closes #50 