### PR TITLE
Add soft-delete RPC and update frontend delete

### DIFF
--- a/my-app/backend/supabase/migrations/20260327120000_soft_delete_post_rpc.sql
+++ b/my-app/backend/supabase/migrations/20260327120000_soft_delete_post_rpc.sql
@@ -1,0 +1,23 @@
+-- Soft delete helper: marks posts.deleted_at instead of hard-deleting rows.
+create or replace function public.soft_delete_post(p_post_id uuid)
+returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  updated_count integer := 0;
+begin
+  update public.posts
+  set deleted_at = timezone('utc', now())
+  where post_id = p_post_id
+    and creator_id = auth.uid()
+    and deleted_at is null;
+
+  get diagnostics updated_count = row_count;
+  return updated_count = 1;
+end;
+$$;
+
+revoke all on function public.soft_delete_post(uuid) from public;
+grant execute on function public.soft_delete_post(uuid) to authenticated;

--- a/my-app/frontend/app/home/_layout.jsx
+++ b/my-app/frontend/app/home/_layout.jsx
@@ -47,13 +47,6 @@ export default function HomeTabsLayout() {
           }}
         />
         <Tabs.Screen
-          name="post"
-          options={{
-            title: 'Post',
-            tabBarIcon: ({ color }) => <IconSymbol size={28} name="square.and.pencil" color={color} />,
-          }}
-        />
-        <Tabs.Screen
           name="projects"
           options={{
             href: null,

--- a/my-app/frontend/constants/exploreItems.js
+++ b/my-app/frontend/constants/exploreItems.js
@@ -610,6 +610,14 @@ export async function deletePostById(postId, userId) {
     throw new Error('Missing post or user information for delete action.');
   }
 
+  const { data: authData, error: authError } = await supabase.auth.getUser();
+  if (authError) throw authError;
+
+  const authUserId = authData?.user?.id || null;
+  if (!authUserId) {
+    throw new Error('No active auth session. Please log in again and retry.');
+  }
+
   const { data: post, error: readError } = await supabase
     .from('posts')
     .select('post_id, creator_id, deleted_at')
@@ -617,15 +625,28 @@ export async function deletePostById(postId, userId) {
     .maybeSingle();
   if (readError) throw readError;
   if (!post) throw new Error('Post not found.');
-  if (post.creator_id !== userId) {
+  if (post.creator_id !== authUserId) {
     throw new Error('You can only delete your own posts.');
+  }
+  if (userId !== authUserId) {
+    throw new Error('Session mismatch detected. Please sign out and sign back in.');
   }
   if (post.deleted_at) return;
 
-  const { error: updateError } = await supabase
-    .from('posts')
-    .update({ deleted_at: new Date().toISOString() })
-    .eq('post_id', postId)
-    .eq('creator_id', userId);
-  if (updateError) throw updateError;
+  const { data: softDeleted, error: rpcError } = await supabase.rpc('soft_delete_post', {
+    p_post_id: postId,
+  });
+
+  if (rpcError?.code === '42501') {
+    throw new Error(
+      `Delete blocked by Supabase RLS (post ${postId}). auth.uid=${authUserId}, creator_id=${post.creator_id}.`
+    );
+  }
+
+  if (rpcError) throw rpcError;
+  if (softDeleted === true) return;
+
+  throw new Error(
+    `Soft delete did not affect any rows (post ${postId}). auth.uid=${authUserId}, creator_id=${post.creator_id}.`
+  );
 }


### PR DESCRIPTION
Create a Supabase RPC (soft_delete_post) to mark posts.deleted_at instead of hard-deleting rows, revoke public access and grant execute to authenticated users. Update frontend: remove the Post tab from home layout; enhance deletePostById to validate the active auth session, ensure session/user ID matches, call the soft_delete_post RPC, and provide clearer errors for RLS rejections or no-ops when no rows are affected.