### PR TITLE
Add per-user channel read state & unread counts

### DIFF
--- a/my-app/backend/supabase/migrations/20260425120000_group_channel_read_state.sql
+++ b/my-app/backend/supabase/migrations/20260425120000_group_channel_read_state.sql
@@ -1,0 +1,77 @@
+-- Per-user read cursor per channel, for unread message counts in the chat list.
+
+create table if not exists public.group_channel_read_state (
+  user_id uuid not null references public.users (user_id) on delete cascade,
+  channel_id uuid not null references public.group_channels (channel_id) on delete cascade,
+  last_read_at timestamptz not null default 'epoch'::timestamptz,
+  primary key (user_id, channel_id)
+);
+
+create index if not exists idx_gcr_state_channel
+  on public.group_channel_read_state (channel_id);
+
+comment on table public.group_channel_read_state is
+  'When the user last marked messages as read in a group channel.';
+
+alter table public.group_channel_read_state enable row level security;
+
+drop policy if exists "Read own channel read state" on public.group_channel_read_state;
+create policy "Read own channel read state"
+  on public.group_channel_read_state
+  for select
+  to authenticated
+  using (user_id = auth.uid());
+
+drop policy if exists "Insert own channel read state" on public.group_channel_read_state;
+create policy "Insert own channel read state"
+  on public.group_channel_read_state
+  for insert
+  to authenticated
+  with check (user_id = auth.uid());
+
+drop policy if exists "Update own channel read state" on public.group_channel_read_state;
+create policy "Update own channel read state"
+  on public.group_channel_read_state
+  for update
+  to authenticated
+  using (user_id = auth.uid())
+  with check (user_id = auth.uid());
+
+-- Count messages from others that are newer than the user''s last_read_at (epoch = never read).
+create or replace function public.get_group_unread_counts(p_channel_ids uuid[])
+returns table (channel_id uuid, unread_count bigint)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select
+    u.cid as channel_id,
+    coalesce((
+      select count(*)::bigint
+      from public.group_messages m
+      where m.channel_id = u.cid
+        and m.user_id <> auth.uid()
+        and m.created_at > coalesce(
+          (
+            select r.last_read_at
+            from public.group_channel_read_state r
+            where r.user_id = auth.uid()
+              and r.channel_id = u.cid
+          ),
+          'epoch'::timestamptz
+        )
+    ), 0) as unread_count
+  from unnest(coalesce(p_channel_ids, array[]::uuid[])) as u(cid)
+  where exists (
+    select 1
+    from public.group_channels gc
+    inner join public.group_members gm
+      on gm.group_id = gc.group_id
+     and gm.user_id = auth.uid()
+    where gc.channel_id = u.cid
+  );
+$$;
+
+revoke all on function public.get_group_unread_counts(uuid[]) from public;
+grant execute on function public.get_group_unread_counts(uuid[]) to authenticated;

--- a/my-app/frontend/app/home/group-chats/[chatId]/index.jsx
+++ b/my-app/frontend/app/home/group-chats/[chatId]/index.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
@@ -13,11 +13,16 @@ import {
   TextInput,
   View,
 } from 'react-native';
-import { router, useLocalSearchParams } from 'expo-router';
+import { router, useFocusEffect, useLocalSearchParams } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useUser } from '@/context/UserContext';
 
-import { fetchGroupChat, normalizeRouteChatId, sendGroupMessage } from '@/lib/groupChats.service';
+import {
+  fetchGroupChat,
+  markGroupChannelAsRead,
+  normalizeRouteChatId,
+  sendGroupMessage,
+} from '@/lib/groupChats.service';
 import {
   pickChatImageFromLibrary,
   resolveChatImageUriForMessage,
@@ -73,6 +78,14 @@ export default function GroupChatDetailsScreen() {
       mounted = false;
     };
   }, [chatId, user?.id]);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (chat?.channelId && user?.id) {
+        void markGroupChannelAsRead(user.id, chat.channelId);
+      }
+    }, [chat?.channelId, user?.id])
+  );
 
   if (loadError) {
     return (
@@ -138,6 +151,9 @@ export default function GroupChatDetailsScreen() {
 
       if (created) {
         setSentMessages((prev) => [...prev, created]);
+        if (user?.id && chat?.channelId) {
+          await markGroupChannelAsRead(user.id, chat.channelId);
+        }
       }
       setMessageText('');
       setPendingImage(null);

--- a/my-app/frontend/app/home/group-chats/index.jsx
+++ b/my-app/frontend/app/home/group-chats/index.jsx
@@ -107,7 +107,11 @@ export default function GroupChatsScreen() {
                   {chat.preview}
                 </Text>
               </View>
-              <Text style={styles.memberText}>{chat.memberCount}</Text>
+              {Number(chat.unreadCount) > 0 ? (
+                <Text style={styles.unreadBadge}>
+                  {Number(chat.unreadCount) > 99 ? '99+' : String(chat.unreadCount)}
+                </Text>
+              ) : null}
             </Pressable>
           ))}
 
@@ -228,10 +232,12 @@ const styles = StyleSheet.create({
     lineHeight: responsive(22, 18, 26),
     marginTop: 2,
   },
-  memberText: {
+  unreadBadge: {
     fontFamily: 'Gaegu-Bold',
     fontSize: responsive(28, 20, 32),
-    color: '#7f6a6a',
+    color: '#5c3d3d',
+    minWidth: responsive(28, 22, 34),
+    textAlign: 'right',
   },
   emptyText: {
     fontFamily: 'Gaegu-Bold',

--- a/my-app/frontend/constants/groupChats.js
+++ b/my-app/frontend/constants/groupChats.js
@@ -4,6 +4,7 @@ export const GROUP_CHATS = [
     name: 'The Big Cats GC',
     preview: 'Does anyone know where to get paint?',
     memberCount: 42,
+    unreadCount: 0,
     coverImage: null,
     members: ['Abby', 'Mina', 'Leo', 'Kay', 'Nora', 'Eli'],
     messages: [
@@ -21,6 +22,7 @@ export const GROUP_CHATS = [
     name: 'Crochet Club',
     preview: 'I found a pastel yarn sale!',
     memberCount: 18,
+    unreadCount: 0,
     coverImage: null,
     members: ['Jules', 'Nina', 'Rose'],
     messages: [
@@ -37,6 +39,7 @@ export const GROUP_CHATS = [
     name: 'Pottery Friends',
     preview: 'Who is free for wheel practice this weekend?',
     memberCount: 12,
+    unreadCount: 0,
     coverImage: null,
     members: ['Ivy', 'Mara', 'Sage'],
     messages: [

--- a/my-app/frontend/lib/groupChats.service.js
+++ b/my-app/frontend/lib/groupChats.service.js
@@ -145,6 +145,59 @@ async function ensureGeneralChannel(groupId) {
   return null;
 }
 
+async function fetchUnreadCountsByChannelIds(channelIds) {
+  const map = new Map();
+  if (!supabase || !channelIds?.length) {
+    return map;
+  }
+  const { data, error } = await supabase.rpc('get_group_unread_counts', {
+    p_channel_ids: channelIds,
+  });
+  if (error) {
+    console.warn('[groupChats] get_group_unread_counts:', error.message);
+    return map;
+  }
+  for (const row of data || []) {
+    if (row?.channel_id != null) {
+      map.set(String(row.channel_id), Number(row.unread_count) || 0);
+    }
+  }
+  return map;
+}
+
+/**
+ * Marks the channel as read through the latest message (or now if empty).
+ * Call when the user opens a group / DM chat.
+ */
+export async function markGroupChannelAsRead(userId, channelId) {
+  if (!supabase || !userId || !channelId) {
+    return;
+  }
+  const { data: lastRow, error: lastErr } = await supabase
+    .from('group_messages')
+    .select('created_at')
+    .eq('channel_id', channelId)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (lastErr) {
+    console.warn('[groupChats] markGroupChannelAsRead last message:', lastErr.message);
+    return;
+  }
+  const lastRead = lastRow?.created_at || new Date().toISOString();
+  const { error } = await supabase.from('group_channel_read_state').upsert(
+    {
+      user_id: userId,
+      channel_id: channelId,
+      last_read_at: lastRead,
+    },
+    { onConflict: 'user_id,channel_id' }
+  );
+  if (error) {
+    console.warn('[groupChats] markGroupChannelAsRead upsert:', error.message);
+  }
+}
+
 export async function fetchGroupChats(currentUserId) {
   if (!supabase) return GROUP_CHATS;
 
@@ -225,6 +278,11 @@ export async function fetchGroupChats(currentUserId) {
     return acc;
   }, {});
 
+  const channelIdList = visibleGroups
+    .map((g) => channelByGroup.get(g.group_id)?.channel_id)
+    .filter(Boolean);
+  const unreadByChannel = await fetchUnreadCountsByChannelIds(channelIdList);
+
   const dbChats = await Promise.all(visibleGroups.map(async (group) => {
     const channel = channelByGroup.get(group.group_id);
     const latestMessage = channel ? latestMessageByChannel.get(channel.channel_id) : null;
@@ -243,11 +301,14 @@ export async function fetchGroupChats(currentUserId) {
     const resolvedCoverImage = isDirect
       ? await resolveAvatarUrl(otherUser?.avatar_url || '')
       : await resolveGroupImageUrl(metadata.image);
+    const chId = channel?.channel_id;
+    const unreadCount = chId != null ? (unreadByChannel.get(String(chId)) ?? 0) : 0;
     return {
       id: group.group_id,
       name: displayName,
       preview: parsed?.text || 'Start chatting...',
       memberCount: memberNames.length,
+      unreadCount,
       coverImage: resolvedCoverImage || null,
       members: memberNames,
       messages: [],
@@ -268,7 +329,7 @@ export async function fetchGroupChats(currentUserId) {
     const chatId = String(chat.id || '');
     const nameKey = String(chat.name || '').trim().toLowerCase();
     return !existingKeys.has(chatId) && !existingNames.has(nameKey);
-  });
+  }).map((c) => ({ ...c, unreadCount: 0 }));
 
   return [...dbChats, ...legacyChats];
   } catch (err) {


### PR DESCRIPTION
Introduce per-user read cursors and unread counts for group channels.

Backend: Add migration to create group_channel_read_state table with RLS policies (select/insert/update limited to the owning user), index, and a security-definer RPC get_group_unread_counts(uuid[]) that returns unread message counts for channels the caller is a member of. Grant execute to authenticated users and revoke public.

Frontend: Add unreadCount support throughout the app: - new fetchUnreadCountsByChannelIds RPC wrapper and markGroupChannelAsRead(upsert last_read_at) in groupChats.service.js; - fetchGroupChats now queries unread counts and sets unreadCount per chat; - when opening a chat (useFocusEffect) and after sending a message, mark the channel as read. UI: render an unread badge in group chat list, add sample unreadCount fields to constants, and tweak badge styles and imports.