### PR TITLE
Add scrapbook DB, frontend service & notifications

### DIFF
--- a/my-app/backend/supabase/migrations/20260310041844_create_initial_schema.sql
+++ b/my-app/backend/supabase/migrations/20260310041844_create_initial_schema.sql
@@ -209,7 +209,8 @@
     "email" text,
     "avatar_url" text,
     "display_name" character varying(50),
-    "level" integer default 1
+    "level" integer default 1,
+    "username" text 
       );
 
 

--- a/my-app/backend/supabase/migrations/20260424120000_post_event_notifications.sql
+++ b/my-app/backend/supabase/migrations/20260424120000_post_event_notifications.sql
@@ -107,6 +107,7 @@ declare
   v_content text;
   v_title text;
   v_actor text;
+  v_like_count integer;
 begin
   select p.creator_id, p.content
   into v_creator, v_content
@@ -118,59 +119,12 @@ begin
     return new;
   end if;
 
+  select count(*)
+  into v_like_count
+  from public.post_likes pl
+  where pl.post_id = new.post_id;
+
   v_title := public.post_title_from_content(v_content);
-  v_actor := public.user_display_name(new.user_id);
-
-  insert into public.notifications (user_id, actor_id, type, target_type, target_id, message_content)
-  values (
-    v_creator,
-    new.user_id,
-    'like',
-    'post',
-    new.post_id,
-    format('%s liked your post "%s".', v_actor, v_title)
-  );
-
-  return new;
-end;
-$$;
-
-drop trigger if exists trg_notify_post_like on public.post_likes;
-create trigger trg_notify_post_like
-  after insert on public.post_likes
-  for each row
-  execute function public.tg_notify_post_like();
-
-create or replace function public.tg_notify_post_like()
-returns trigger
-language plpgsql
-security definer
-set search_path = public
-as $$
-declare
-v_creator uuid;
-  v_content text;
-  v_title text;
-  v_actor text;
-  v_like_count integer;
-begin
-select p.creator_id, p.content
-into v_creator, v_content
-from public.posts p
-where p.post_id = new.post_id
-  and p.deleted_at is null;
-
--- Do not notify if post is missing/deleted or user liked their own post
-if v_creator is null or v_creator = new.user_id then
-    return new;
-end if;
-
-select count(*)
-into v_like_count
-from public.post_likes pl
-where pl.post_id = new.post_id;
-
-v_title := public.post_title_from_content(v_content);
   v_actor := public.user_display_name(new.user_id);
 
   -- First 5 likes: notify every like individually
@@ -210,9 +164,54 @@ v_title := public.post_title_from_content(v_content);
       new.post_id,
       format('You have %s new likes on your post "%s"!', v_like_count, v_title)
     );
-end if;
+  end if;
 
-return new;
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_notify_post_like on public.post_likes;
+create trigger trg_notify_post_like
+  after insert on public.post_likes
+  for each row
+  execute function public.tg_notify_post_like();
+
+create or replace function public.tg_notify_post_save()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_creator uuid;
+  v_content text;
+  v_title text;
+  v_actor text;
+begin
+  select p.creator_id, p.content
+  into v_creator, v_content
+  from public.posts p
+  where p.post_id = new.post_id
+    and p.deleted_at is null;
+
+  if v_creator is null or v_creator = new.user_id then
+    return new;
+  end if;
+
+  v_title := public.post_title_from_content(v_content);
+  v_actor := public.user_display_name(new.user_id);
+
+  insert into public.notifications (user_id, actor_id, type, target_type, target_id, message_content)
+  values (
+    v_creator,
+    new.user_id,
+    'save',
+    'post',
+    new.post_id,
+    format('%s saved your post "%s".', v_actor, v_title)
+  );
+
+  return new;
 end;
 $$;
 

--- a/my-app/backend/supabase/migrations/20260426120000_scrapbook_my_projects.sql
+++ b/my-app/backend/supabase/migrations/20260426120000_scrapbook_my_projects.sql
@@ -1,0 +1,335 @@
+-- Maps frontend state in my-app/frontend/app/home/projects.jsx to persistent tables.
+-- Intentionally separate from public.projects (collaborative / feed projects).
+
+create table public.scrapbook_projects (
+  scrapbook_project_id uuid not null default gen_random_uuid(),
+  owner_id uuid not null references public.users (user_id) on delete cascade,
+  name text not null,
+  completed boolean not null default false,
+  cover_url text,
+  last_edited_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (scrapbook_project_id)
+);
+
+create table public.scrapbook_folders (
+  scrapbook_folder_id uuid not null default gen_random_uuid(),
+  scrapbook_project_id uuid not null references public.scrapbook_projects (scrapbook_project_id) on delete cascade,
+  name text not null,
+  last_edited_at timestamptz not null default now(),
+  sort_order integer not null default 0,
+  primary key (scrapbook_folder_id)
+);
+
+create table public.scrapbook_folder_files (
+  scrapbook_folder_file_id uuid not null default gen_random_uuid(),
+  scrapbook_folder_id uuid not null references public.scrapbook_folders (scrapbook_folder_id) on delete cascade,
+  file_url text not null,
+  sort_order integer not null default 0,
+  primary key (scrapbook_folder_file_id)
+);
+
+create table public.scrapbook_canvas_elements (
+  canvas_element_id uuid not null default gen_random_uuid(),
+  scrapbook_project_id uuid not null references public.scrapbook_projects (scrapbook_project_id) on delete cascade,
+  element_type text not null,
+  content text not null,
+  x double precision not null,
+  y double precision not null,
+  width double precision not null,
+  height double precision not null,
+  sort_order integer not null default 0,
+  created_at timestamptz not null default now(),
+  primary key (canvas_element_id),
+  constraint scrapbook_canvas_elements_type_chk check (element_type in ('text', 'photo'))
+);
+
+create table public.scrapbook_inspiration_images (
+  inspiration_id uuid not null default gen_random_uuid(),
+  owner_id uuid not null references public.users (user_id) on delete cascade,
+  image_url text not null,
+  sort_order integer not null default 0,
+  created_at timestamptz not null default now(),
+  primary key (inspiration_id)
+);
+
+create table public.scrapbook_list_items (
+  list_item_id uuid not null default gen_random_uuid(),
+  owner_id uuid not null references public.users (user_id) on delete cascade,
+  item_text text not null,
+  is_checked boolean not null default false,
+  is_bulleted boolean not null default true,
+  sort_order integer not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (list_item_id)
+);
+
+create index idx_scrapbook_projects_owner on public.scrapbook_projects (owner_id);
+create index idx_scrapbook_folders_project on public.scrapbook_folders (scrapbook_project_id);
+create index idx_scrapbook_folder_files_folder on public.scrapbook_folder_files (scrapbook_folder_id);
+create index idx_scrapbook_canvas_project on public.scrapbook_canvas_elements (scrapbook_project_id);
+create index idx_scrapbook_inspirations_owner on public.scrapbook_inspiration_images (owner_id);
+create index idx_scrapbook_list_items_owner on public.scrapbook_list_items (owner_id);
+
+comment on table public.scrapbook_projects is
+  'Personal project cards from the My Projects screen; UI field mapping: name, completed, cover->cover_url, lastEditedAt->last_edited_at.';
+comment on table public.scrapbook_canvas_elements is
+  'Free-form canvas items per project; UI: type->element_type, content, x, y, width, height; array order->sort_order.';
+comment on table public.scrapbook_folders is
+  'Folders nested under a scrapbook project; UI: folders[].';
+comment on table public.scrapbook_folder_files is
+  'Image URIs inside a folder; UI: folder.files[].';
+comment on table public.scrapbook_inspiration_images is
+  'Inspirations tab; per-user, not tied to a single project; UI: inspirationImages[].uri.';
+comment on table public.scrapbook_list_items is
+  'Lists tab; per-user; UI: text, checked, bulleted, display order->sort_order.';
+
+-- Row level security: data is private to the owning user.
+alter table public.scrapbook_projects enable row level security;
+alter table public.scrapbook_folders enable row level security;
+alter table public.scrapbook_folder_files enable row level security;
+alter table public.scrapbook_canvas_elements enable row level security;
+alter table public.scrapbook_inspiration_images enable row level security;
+alter table public.scrapbook_list_items enable row level security;
+
+drop policy if exists "Scrapbook projects: select own" on public.scrapbook_projects;
+create policy "Scrapbook projects: select own"
+  on public.scrapbook_projects for select to authenticated
+  using (owner_id = auth.uid());
+
+drop policy if exists "Scrapbook projects: insert own" on public.scrapbook_projects;
+create policy "Scrapbook projects: insert own"
+  on public.scrapbook_projects for insert to authenticated
+  with check (owner_id = auth.uid());
+
+drop policy if exists "Scrapbook projects: update own" on public.scrapbook_projects;
+create policy "Scrapbook projects: update own"
+  on public.scrapbook_projects for update to authenticated
+  using (owner_id = auth.uid())
+  with check (owner_id = auth.uid());
+
+drop policy if exists "Scrapbook projects: delete own" on public.scrapbook_projects;
+create policy "Scrapbook projects: delete own"
+  on public.scrapbook_projects for delete to authenticated
+  using (owner_id = auth.uid());
+
+drop policy if exists "Scrapbook folders: select own" on public.scrapbook_folders;
+create policy "Scrapbook folders: select own"
+  on public.scrapbook_folders for select to authenticated
+  using (
+    exists (
+      select 1 from public.scrapbook_projects p
+      where p.scrapbook_project_id = scrapbook_folders.scrapbook_project_id
+        and p.owner_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Scrapbook folders: insert own" on public.scrapbook_folders;
+create policy "Scrapbook folders: insert own"
+  on public.scrapbook_folders for insert to authenticated
+  with check (
+    exists (
+      select 1 from public.scrapbook_projects p
+      where p.scrapbook_project_id = scrapbook_folders.scrapbook_project_id
+        and p.owner_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Scrapbook folders: update own" on public.scrapbook_folders;
+create policy "Scrapbook folders: update own"
+  on public.scrapbook_folders for update to authenticated
+  using (
+    exists (
+      select 1 from public.scrapbook_projects p
+      where p.scrapbook_project_id = scrapbook_folders.scrapbook_project_id
+        and p.owner_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1 from public.scrapbook_projects p
+      where p.scrapbook_project_id = scrapbook_folders.scrapbook_project_id
+        and p.owner_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Scrapbook folders: delete own" on public.scrapbook_folders;
+create policy "Scrapbook folders: delete own"
+  on public.scrapbook_folders for delete to authenticated
+  using (
+    exists (
+      select 1 from public.scrapbook_projects p
+      where p.scrapbook_project_id = scrapbook_folders.scrapbook_project_id
+        and p.owner_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Scrapbook folder files: select own" on public.scrapbook_folder_files;
+create policy "Scrapbook folder files: select own"
+  on public.scrapbook_folder_files for select to authenticated
+  using (
+    exists (
+      select 1
+      from public.scrapbook_folders f
+      join public.scrapbook_projects p on p.scrapbook_project_id = f.scrapbook_project_id
+      where f.scrapbook_folder_id = scrapbook_folder_files.scrapbook_folder_id
+        and p.owner_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Scrapbook folder files: insert own" on public.scrapbook_folder_files;
+create policy "Scrapbook folder files: insert own"
+  on public.scrapbook_folder_files for insert to authenticated
+  with check (
+    exists (
+      select 1
+      from public.scrapbook_folders f
+      join public.scrapbook_projects p on p.scrapbook_project_id = f.scrapbook_project_id
+      where f.scrapbook_folder_id = scrapbook_folder_files.scrapbook_folder_id
+        and p.owner_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Scrapbook folder files: update own" on public.scrapbook_folder_files;
+create policy "Scrapbook folder files: update own"
+  on public.scrapbook_folder_files for update to authenticated
+  using (
+    exists (
+      select 1
+      from public.scrapbook_folders f
+      join public.scrapbook_projects p on p.scrapbook_project_id = f.scrapbook_project_id
+      where f.scrapbook_folder_id = scrapbook_folder_files.scrapbook_folder_id
+        and p.owner_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.scrapbook_folders f
+      join public.scrapbook_projects p on p.scrapbook_project_id = f.scrapbook_project_id
+      where f.scrapbook_folder_id = scrapbook_folder_files.scrapbook_folder_id
+        and p.owner_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Scrapbook folder files: delete own" on public.scrapbook_folder_files;
+create policy "Scrapbook folder files: delete own"
+  on public.scrapbook_folder_files for delete to authenticated
+  using (
+    exists (
+      select 1
+      from public.scrapbook_folders f
+      join public.scrapbook_projects p on p.scrapbook_project_id = f.scrapbook_project_id
+      where f.scrapbook_folder_id = scrapbook_folder_files.scrapbook_folder_id
+        and p.owner_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Scrapbook canvas: select own" on public.scrapbook_canvas_elements;
+create policy "Scrapbook canvas: select own"
+  on public.scrapbook_canvas_elements for select to authenticated
+  using (
+    exists (
+      select 1 from public.scrapbook_projects p
+      where p.scrapbook_project_id = scrapbook_canvas_elements.scrapbook_project_id
+        and p.owner_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Scrapbook canvas: insert own" on public.scrapbook_canvas_elements;
+create policy "Scrapbook canvas: insert own"
+  on public.scrapbook_canvas_elements for insert to authenticated
+  with check (
+    exists (
+      select 1 from public.scrapbook_projects p
+      where p.scrapbook_project_id = scrapbook_canvas_elements.scrapbook_project_id
+        and p.owner_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Scrapbook canvas: update own" on public.scrapbook_canvas_elements;
+create policy "Scrapbook canvas: update own"
+  on public.scrapbook_canvas_elements for update to authenticated
+  using (
+    exists (
+      select 1 from public.scrapbook_projects p
+      where p.scrapbook_project_id = scrapbook_canvas_elements.scrapbook_project_id
+        and p.owner_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1 from public.scrapbook_projects p
+      where p.scrapbook_project_id = scrapbook_canvas_elements.scrapbook_project_id
+        and p.owner_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Scrapbook canvas: delete own" on public.scrapbook_canvas_elements;
+create policy "Scrapbook canvas: delete own"
+  on public.scrapbook_canvas_elements for delete to authenticated
+  using (
+    exists (
+      select 1 from public.scrapbook_projects p
+      where p.scrapbook_project_id = scrapbook_canvas_elements.scrapbook_project_id
+        and p.owner_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Scrapbook inspirations: select own" on public.scrapbook_inspiration_images;
+create policy "Scrapbook inspirations: select own"
+  on public.scrapbook_inspiration_images for select to authenticated
+  using (owner_id = auth.uid());
+
+drop policy if exists "Scrapbook inspirations: insert own" on public.scrapbook_inspiration_images;
+create policy "Scrapbook inspirations: insert own"
+  on public.scrapbook_inspiration_images for insert to authenticated
+  with check (owner_id = auth.uid());
+
+drop policy if exists "Scrapbook inspirations: update own" on public.scrapbook_inspiration_images;
+create policy "Scrapbook inspirations: update own"
+  on public.scrapbook_inspiration_images for update to authenticated
+  using (owner_id = auth.uid())
+  with check (owner_id = auth.uid());
+
+drop policy if exists "Scrapbook inspirations: delete own" on public.scrapbook_inspiration_images;
+create policy "Scrapbook inspirations: delete own"
+  on public.scrapbook_inspiration_images for delete to authenticated
+  using (owner_id = auth.uid());
+
+drop policy if exists "Scrapbook list items: select own" on public.scrapbook_list_items;
+create policy "Scrapbook list items: select own"
+  on public.scrapbook_list_items for select to authenticated
+  using (owner_id = auth.uid());
+
+drop policy if exists "Scrapbook list items: insert own" on public.scrapbook_list_items;
+create policy "Scrapbook list items: insert own"
+  on public.scrapbook_list_items for insert to authenticated
+  with check (owner_id = auth.uid());
+
+drop policy if exists "Scrapbook list items: update own" on public.scrapbook_list_items;
+create policy "Scrapbook list items: update own"
+  on public.scrapbook_list_items for update to authenticated
+  using (owner_id = auth.uid())
+  with check (owner_id = auth.uid());
+
+drop policy if exists "Scrapbook list items: delete own" on public.scrapbook_list_items;
+create policy "Scrapbook list items: delete own"
+  on public.scrapbook_list_items for delete to authenticated
+  using (owner_id = auth.uid());
+
+grant select, insert, update, delete on table public.scrapbook_projects to authenticated;
+grant select, insert, update, delete on table public.scrapbook_folders to authenticated;
+grant select, insert, update, delete on table public.scrapbook_folder_files to authenticated;
+grant select, insert, update, delete on table public.scrapbook_canvas_elements to authenticated;
+grant select, insert, update, delete on table public.scrapbook_inspiration_images to authenticated;
+grant select, insert, update, delete on table public.scrapbook_list_items to authenticated;
+
+grant select, insert, update, delete on table public.scrapbook_projects to service_role;
+grant select, insert, update, delete on table public.scrapbook_folders to service_role;
+grant select, insert, update, delete on table public.scrapbook_folder_files to service_role;
+grant select, insert, update, delete on table public.scrapbook_canvas_elements to service_role;
+grant select, insert, update, delete on table public.scrapbook_inspiration_images to service_role;
+grant select, insert, update, delete on table public.scrapbook_list_items to service_role;

--- a/my-app/backend/supabase/migrations/20260428120000_scrapbook_ensure_tables.sql
+++ b/my-app/backend/supabase/migrations/20260428120000_scrapbook_ensure_tables.sql
@@ -1,0 +1,334 @@
+-- Repair: create scrapbook tables if they are missing (e.g. migration version was recorded but DDL did not run).
+-- Safe to run when tables already exist (IF NOT EXISTS).
+
+create table if not exists public.scrapbook_projects (
+  scrapbook_project_id uuid not null default gen_random_uuid(),
+  owner_id uuid not null references public.users (user_id) on delete cascade,
+  name text not null,
+  completed boolean not null default false,
+  cover_url text,
+  last_edited_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (scrapbook_project_id)
+);
+
+create table if not exists public.scrapbook_folders (
+  scrapbook_folder_id uuid not null default gen_random_uuid(),
+  scrapbook_project_id uuid not null references public.scrapbook_projects (scrapbook_project_id) on delete cascade,
+  name text not null,
+  last_edited_at timestamptz not null default now(),
+  sort_order integer not null default 0,
+  primary key (scrapbook_folder_id)
+);
+
+create table if not exists public.scrapbook_folder_files (
+  scrapbook_folder_file_id uuid not null default gen_random_uuid(),
+  scrapbook_folder_id uuid not null references public.scrapbook_folders (scrapbook_folder_id) on delete cascade,
+  file_url text not null,
+  sort_order integer not null default 0,
+  primary key (scrapbook_folder_file_id)
+);
+
+create table if not exists public.scrapbook_canvas_elements (
+  canvas_element_id uuid not null default gen_random_uuid(),
+  scrapbook_project_id uuid not null references public.scrapbook_projects (scrapbook_project_id) on delete cascade,
+  element_type text not null,
+  content text not null,
+  x double precision not null,
+  y double precision not null,
+  width double precision not null,
+  height double precision not null,
+  sort_order integer not null default 0,
+  created_at timestamptz not null default now(),
+  primary key (canvas_element_id),
+  constraint scrapbook_canvas_elements_type_chk check (element_type in ('text', 'photo'))
+);
+
+create table if not exists public.scrapbook_inspiration_images (
+  inspiration_id uuid not null default gen_random_uuid(),
+  owner_id uuid not null references public.users (user_id) on delete cascade,
+  image_url text not null,
+  sort_order integer not null default 0,
+  created_at timestamptz not null default now(),
+  primary key (inspiration_id)
+);
+
+create table if not exists public.scrapbook_list_items (
+  list_item_id uuid not null default gen_random_uuid(),
+  owner_id uuid not null references public.users (user_id) on delete cascade,
+  item_text text not null,
+  is_checked boolean not null default false,
+  is_bulleted boolean not null default true,
+  sort_order integer not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (list_item_id)
+);
+
+create index if not exists idx_scrapbook_projects_owner on public.scrapbook_projects (owner_id);
+create index if not exists idx_scrapbook_folders_project on public.scrapbook_folders (scrapbook_project_id);
+create index if not exists idx_scrapbook_folder_files_folder on public.scrapbook_folder_files (scrapbook_folder_id);
+create index if not exists idx_scrapbook_canvas_project on public.scrapbook_canvas_elements (scrapbook_project_id);
+create index if not exists idx_scrapbook_inspirations_owner on public.scrapbook_inspiration_images (owner_id);
+create index if not exists idx_scrapbook_list_items_owner on public.scrapbook_list_items (owner_id);
+
+comment on table public.scrapbook_projects is
+  'Personal project cards from the My Projects screen; UI field mapping: name, completed, cover->cover_url, lastEditedAt->last_edited_at.';
+comment on table public.scrapbook_canvas_elements is
+  'Free-form canvas items per project; UI: type->element_type, content, x, y, width, height; array order->sort_order.';
+comment on table public.scrapbook_folders is
+  'Folders nested under a scrapbook project; UI: folders[].';
+comment on table public.scrapbook_folder_files is
+  'Image URIs inside a folder; UI: folder.files[].';
+comment on table public.scrapbook_inspiration_images is
+  'Inspirations tab; per-user, not tied to a single project; UI: inspirationImages[].uri.';
+comment on table public.scrapbook_list_items is
+  'Lists tab; per-user; UI: text, checked, bulleted, display order->sort_order.';
+
+alter table public.scrapbook_projects enable row level security;
+alter table public.scrapbook_folders enable row level security;
+alter table public.scrapbook_folder_files enable row level security;
+alter table public.scrapbook_canvas_elements enable row level security;
+alter table public.scrapbook_inspiration_images enable row level security;
+alter table public.scrapbook_list_items enable row level security;
+
+drop policy if exists "Scrapbook projects: select own" on public.scrapbook_projects;
+create policy "Scrapbook projects: select own"
+  on public.scrapbook_projects for select to authenticated
+  using (owner_id = auth.uid());
+
+drop policy if exists "Scrapbook projects: insert own" on public.scrapbook_projects;
+create policy "Scrapbook projects: insert own"
+  on public.scrapbook_projects for insert to authenticated
+  with check (owner_id = auth.uid());
+
+drop policy if exists "Scrapbook projects: update own" on public.scrapbook_projects;
+create policy "Scrapbook projects: update own"
+  on public.scrapbook_projects for update to authenticated
+  using (owner_id = auth.uid())
+  with check (owner_id = auth.uid());
+
+drop policy if exists "Scrapbook projects: delete own" on public.scrapbook_projects;
+create policy "Scrapbook projects: delete own"
+  on public.scrapbook_projects for delete to authenticated
+  using (owner_id = auth.uid());
+
+drop policy if exists "Scrapbook folders: select own" on public.scrapbook_folders;
+create policy "Scrapbook folders: select own"
+  on public.scrapbook_folders for select to authenticated
+  using (
+    exists (
+      select 1 from public.scrapbook_projects p
+      where p.scrapbook_project_id = scrapbook_folders.scrapbook_project_id
+        and p.owner_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Scrapbook folders: insert own" on public.scrapbook_folders;
+create policy "Scrapbook folders: insert own"
+  on public.scrapbook_folders for insert to authenticated
+  with check (
+    exists (
+      select 1 from public.scrapbook_projects p
+      where p.scrapbook_project_id = scrapbook_folders.scrapbook_project_id
+        and p.owner_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Scrapbook folders: update own" on public.scrapbook_folders;
+create policy "Scrapbook folders: update own"
+  on public.scrapbook_folders for update to authenticated
+  using (
+    exists (
+      select 1 from public.scrapbook_projects p
+      where p.scrapbook_project_id = scrapbook_folders.scrapbook_project_id
+        and p.owner_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1 from public.scrapbook_projects p
+      where p.scrapbook_project_id = scrapbook_folders.scrapbook_project_id
+        and p.owner_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Scrapbook folders: delete own" on public.scrapbook_folders;
+create policy "Scrapbook folders: delete own"
+  on public.scrapbook_folders for delete to authenticated
+  using (
+    exists (
+      select 1 from public.scrapbook_projects p
+      where p.scrapbook_project_id = scrapbook_folders.scrapbook_project_id
+        and p.owner_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Scrapbook folder files: select own" on public.scrapbook_folder_files;
+create policy "Scrapbook folder files: select own"
+  on public.scrapbook_folder_files for select to authenticated
+  using (
+    exists (
+      select 1
+      from public.scrapbook_folders f
+      join public.scrapbook_projects p on p.scrapbook_project_id = f.scrapbook_project_id
+      where f.scrapbook_folder_id = scrapbook_folder_files.scrapbook_folder_id
+        and p.owner_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Scrapbook folder files: insert own" on public.scrapbook_folder_files;
+create policy "Scrapbook folder files: insert own"
+  on public.scrapbook_folder_files for insert to authenticated
+  with check (
+    exists (
+      select 1
+      from public.scrapbook_folders f
+      join public.scrapbook_projects p on p.scrapbook_project_id = f.scrapbook_project_id
+      where f.scrapbook_folder_id = scrapbook_folder_files.scrapbook_folder_id
+        and p.owner_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Scrapbook folder files: update own" on public.scrapbook_folder_files;
+create policy "Scrapbook folder files: update own"
+  on public.scrapbook_folder_files for update to authenticated
+  using (
+    exists (
+      select 1
+      from public.scrapbook_folders f
+      join public.scrapbook_projects p on p.scrapbook_project_id = f.scrapbook_project_id
+      where f.scrapbook_folder_id = scrapbook_folder_files.scrapbook_folder_id
+        and p.owner_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.scrapbook_folders f
+      join public.scrapbook_projects p on p.scrapbook_project_id = f.scrapbook_project_id
+      where f.scrapbook_folder_id = scrapbook_folder_files.scrapbook_folder_id
+        and p.owner_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Scrapbook folder files: delete own" on public.scrapbook_folder_files;
+create policy "Scrapbook folder files: delete own"
+  on public.scrapbook_folder_files for delete to authenticated
+  using (
+    exists (
+      select 1
+      from public.scrapbook_folders f
+      join public.scrapbook_projects p on p.scrapbook_project_id = f.scrapbook_project_id
+      where f.scrapbook_folder_id = scrapbook_folder_files.scrapbook_folder_id
+        and p.owner_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Scrapbook canvas: select own" on public.scrapbook_canvas_elements;
+create policy "Scrapbook canvas: select own"
+  on public.scrapbook_canvas_elements for select to authenticated
+  using (
+    exists (
+      select 1 from public.scrapbook_projects p
+      where p.scrapbook_project_id = scrapbook_canvas_elements.scrapbook_project_id
+        and p.owner_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Scrapbook canvas: insert own" on public.scrapbook_canvas_elements;
+create policy "Scrapbook canvas: insert own"
+  on public.scrapbook_canvas_elements for insert to authenticated
+  with check (
+    exists (
+      select 1 from public.scrapbook_projects p
+      where p.scrapbook_project_id = scrapbook_canvas_elements.scrapbook_project_id
+        and p.owner_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Scrapbook canvas: update own" on public.scrapbook_canvas_elements;
+create policy "Scrapbook canvas: update own"
+  on public.scrapbook_canvas_elements for update to authenticated
+  using (
+    exists (
+      select 1 from public.scrapbook_projects p
+      where p.scrapbook_project_id = scrapbook_canvas_elements.scrapbook_project_id
+        and p.owner_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1 from public.scrapbook_projects p
+      where p.scrapbook_project_id = scrapbook_canvas_elements.scrapbook_project_id
+        and p.owner_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Scrapbook canvas: delete own" on public.scrapbook_canvas_elements;
+create policy "Scrapbook canvas: delete own"
+  on public.scrapbook_canvas_elements for delete to authenticated
+  using (
+    exists (
+      select 1 from public.scrapbook_projects p
+      where p.scrapbook_project_id = scrapbook_canvas_elements.scrapbook_project_id
+        and p.owner_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Scrapbook inspirations: select own" on public.scrapbook_inspiration_images;
+create policy "Scrapbook inspirations: select own"
+  on public.scrapbook_inspiration_images for select to authenticated
+  using (owner_id = auth.uid());
+
+drop policy if exists "Scrapbook inspirations: insert own" on public.scrapbook_inspiration_images;
+create policy "Scrapbook inspirations: insert own"
+  on public.scrapbook_inspiration_images for insert to authenticated
+  with check (owner_id = auth.uid());
+
+drop policy if exists "Scrapbook inspirations: update own" on public.scrapbook_inspiration_images;
+create policy "Scrapbook inspirations: update own"
+  on public.scrapbook_inspiration_images for update to authenticated
+  using (owner_id = auth.uid())
+  with check (owner_id = auth.uid());
+
+drop policy if exists "Scrapbook inspirations: delete own" on public.scrapbook_inspiration_images;
+create policy "Scrapbook inspirations: delete own"
+  on public.scrapbook_inspiration_images for delete to authenticated
+  using (owner_id = auth.uid());
+
+drop policy if exists "Scrapbook list items: select own" on public.scrapbook_list_items;
+create policy "Scrapbook list items: select own"
+  on public.scrapbook_list_items for select to authenticated
+  using (owner_id = auth.uid());
+
+drop policy if exists "Scrapbook list items: insert own" on public.scrapbook_list_items;
+create policy "Scrapbook list items: insert own"
+  on public.scrapbook_list_items for insert to authenticated
+  with check (owner_id = auth.uid());
+
+drop policy if exists "Scrapbook list items: update own" on public.scrapbook_list_items;
+create policy "Scrapbook list items: update own"
+  on public.scrapbook_list_items for update to authenticated
+  using (owner_id = auth.uid())
+  with check (owner_id = auth.uid());
+
+drop policy if exists "Scrapbook list items: delete own" on public.scrapbook_list_items;
+create policy "Scrapbook list items: delete own"
+  on public.scrapbook_list_items for delete to authenticated
+  using (owner_id = auth.uid());
+
+grant select, insert, update, delete on table public.scrapbook_projects to authenticated;
+grant select, insert, update, delete on table public.scrapbook_folders to authenticated;
+grant select, insert, update, delete on table public.scrapbook_folder_files to authenticated;
+grant select, insert, update, delete on table public.scrapbook_canvas_elements to authenticated;
+grant select, insert, update, delete on table public.scrapbook_inspiration_images to authenticated;
+grant select, insert, update, delete on table public.scrapbook_list_items to authenticated;
+
+grant select, insert, update, delete on table public.scrapbook_projects to service_role;
+grant select, insert, update, delete on table public.scrapbook_folders to service_role;
+grant select, insert, update, delete on table public.scrapbook_folder_files to service_role;
+grant select, insert, update, delete on table public.scrapbook_canvas_elements to service_role;
+grant select, insert, update, delete on table public.scrapbook_inspiration_images to service_role;
+grant select, insert, update, delete on table public.scrapbook_list_items to service_role;

--- a/my-app/backend/supabase/schemas/8_scrapbook_my_projects.sql
+++ b/my-app/backend/supabase/schemas/8_scrapbook_my_projects.sql
@@ -1,0 +1,74 @@
+-- Personal "My Projects" workspace from the mobile UI (projects.jsx).
+-- Separate from public.collaborative `projects` / `project_members` / `project_tags`.
+
+create table "scrapbook_projects" (
+  "scrapbook_project_id" uuid not null default gen_random_uuid(),
+  "owner_id" uuid not null references "users" ("user_id") on delete cascade,
+  "name" text not null,
+  "completed" boolean not null default false,
+  "cover_url" text,
+  "last_edited_at" timestamp with time zone not null default now(),
+  "created_at" timestamp with time zone not null default now(),
+  "updated_at" timestamp with time zone not null default now(),
+  primary key ("scrapbook_project_id")
+);
+
+create table "scrapbook_folders" (
+  "scrapbook_folder_id" uuid not null default gen_random_uuid(),
+  "scrapbook_project_id" uuid not null references "scrapbook_projects" ("scrapbook_project_id") on delete cascade,
+  "name" text not null,
+  "last_edited_at" timestamp with time zone not null default now(),
+  "sort_order" integer not null default 0,
+  primary key ("scrapbook_folder_id")
+);
+
+create table "scrapbook_folder_files" (
+  "scrapbook_folder_file_id" uuid not null default gen_random_uuid(),
+  "scrapbook_folder_id" uuid not null references "scrapbook_folders" ("scrapbook_folder_id") on delete cascade,
+  "file_url" text not null,
+  "sort_order" integer not null default 0,
+  primary key ("scrapbook_folder_file_id")
+);
+
+create table "scrapbook_canvas_elements" (
+  "canvas_element_id" uuid not null default gen_random_uuid(),
+  "scrapbook_project_id" uuid not null references "scrapbook_projects" ("scrapbook_project_id") on delete cascade,
+  "element_type" text not null,
+  "content" text not null,
+  "x" double precision not null,
+  "y" double precision not null,
+  "width" double precision not null,
+  "height" double precision not null,
+  "sort_order" integer not null default 0,
+  "created_at" timestamp with time zone not null default now(),
+  primary key ("canvas_element_id"),
+  constraint "scrapbook_canvas_elements_type_chk" check ("element_type" in ('text', 'photo'))
+);
+
+create table "scrapbook_inspiration_images" (
+  "inspiration_id" uuid not null default gen_random_uuid(),
+  "owner_id" uuid not null references "users" ("user_id") on delete cascade,
+  "image_url" text not null,
+  "sort_order" integer not null default 0,
+  "created_at" timestamp with time zone not null default now(),
+  primary key ("inspiration_id")
+);
+
+create table "scrapbook_list_items" (
+  "list_item_id" uuid not null default gen_random_uuid(),
+  "owner_id" uuid not null references "users" ("user_id") on delete cascade,
+  "item_text" text not null,
+  "is_checked" boolean not null default false,
+  "is_bulleted" boolean not null default true,
+  "sort_order" integer not null default 0,
+  "created_at" timestamp with time zone not null default now(),
+  "updated_at" timestamp with time zone not null default now(),
+  primary key ("list_item_id")
+);
+
+create index "idx_scrapbook_projects_owner" on "scrapbook_projects" ("owner_id");
+create index "idx_scrapbook_folders_project" on "scrapbook_folders" ("scrapbook_project_id");
+create index "idx_scrapbook_folder_files_folder" on "scrapbook_folder_files" ("scrapbook_folder_id");
+create index "idx_scrapbook_canvas_project" on "scrapbook_canvas_elements" ("scrapbook_project_id");
+create index "idx_scrapbook_inspirations_owner" on "scrapbook_inspiration_images" ("owner_id");
+create index "idx_scrapbook_list_items_owner" on "scrapbook_list_items" ("owner_id");

--- a/my-app/frontend/FE-services/scrapbook.service.js
+++ b/my-app/frontend/FE-services/scrapbook.service.js
@@ -1,0 +1,263 @@
+import { supabase } from '@/lib/supabaseClient';
+
+const isUuid = (s) =>
+  typeof s === 'string' && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(s);
+
+function mapRowToProject(row, defaultCover) {
+  return {
+    id: row.scrapbook_project_id,
+    name: row.name,
+    completed: row.completed,
+    lastEditedAt: new Date(row.last_edited_at).getTime(),
+    cover: row.cover_url || defaultCover,
+    folders: [],
+  };
+}
+
+function mapElementRow(row) {
+  return {
+    id: row.canvas_element_id,
+    type: row.element_type,
+    content: row.content,
+    x: row.x,
+    y: row.y,
+    width: row.width,
+    height: row.height,
+  };
+}
+
+function mapInspoRow(row) {
+  return { id: row.inspiration_id, uri: row.image_url };
+}
+
+function mapListRow(row) {
+  return {
+    id: row.list_item_id,
+    text: row.item_text,
+    checked: row.is_checked,
+    bulleted: row.is_bulleted,
+  };
+}
+
+/**
+ * @param {string} userId
+ * @param {string} defaultProjectCoverUri
+ * @returns {Promise<{
+ *   projects: any[],
+ *   projectElements: Record<string, any[]>,
+ *   inspirationImages: any[],
+ *   listItems: any[]
+ * }>}
+ */
+export async function loadScrapbookWorkspace(userId, defaultProjectCoverUri) {
+  if (!supabase || !userId) {
+    return { projects: [], projectElements: {}, inspirationImages: [], listItems: [] };
+  }
+
+  const { data: projectRows, error: projectsError } = await supabase
+    .from('scrapbook_projects')
+    .select('*')
+    .eq('owner_id', userId)
+    .order('last_edited_at', { ascending: false });
+
+  if (projectsError) throw projectsError;
+
+  const projects = (projectRows || []).map((r) => mapRowToProject(r, defaultProjectCoverUri));
+  const projectIds = projects.map((p) => p.id);
+  if (!projectIds.length) {
+    const { data: insp, error: inspError } = await supabase
+      .from('scrapbook_inspiration_images')
+      .select('*')
+      .eq('owner_id', userId)
+      .order('sort_order', { ascending: true });
+    if (inspError) throw inspError;
+    const { data: list, error: listError } = await supabase
+      .from('scrapbook_list_items')
+      .select('*')
+      .eq('owner_id', userId)
+      .order('sort_order', { ascending: true });
+    if (listError) throw listError;
+    return {
+      projects: [],
+      projectElements: {},
+      inspirationImages: (insp || []).map(mapInspoRow),
+      listItems: (list || []).map(mapListRow),
+    };
+  }
+
+  const { data: elRows, error: elError } = await supabase
+    .from('scrapbook_canvas_elements')
+    .select('*')
+    .in('scrapbook_project_id', projectIds)
+    .order('sort_order', { ascending: true });
+  if (elError) throw elError;
+
+  const projectElements = {};
+  for (const pid of projectIds) projectElements[pid] = [];
+  for (const r of elRows || []) {
+    if (!projectElements[r.scrapbook_project_id]) projectElements[r.scrapbook_project_id] = [];
+    projectElements[r.scrapbook_project_id].push(mapElementRow(r));
+  }
+
+  const { data: insp, error: inspError } = await supabase
+    .from('scrapbook_inspiration_images')
+    .select('*')
+    .eq('owner_id', userId)
+    .order('sort_order', { ascending: true });
+  if (inspError) throw inspError;
+
+  const { data: list, error: listError } = await supabase
+    .from('scrapbook_list_items')
+    .select('*')
+    .eq('owner_id', userId)
+    .order('sort_order', { ascending: true });
+  if (listError) throw listError;
+
+  return {
+    projects,
+    projectElements,
+    inspirationImages: (insp || []).map(mapInspoRow),
+    listItems: (list || []).map(mapListRow),
+  };
+}
+
+/**
+ * @param {string} userId
+ * @param {{ name: string, completed: boolean, cover_url: string | null, defaultProjectCoverUri: string }}
+ */
+export async function insertScrapbookProject(userId, { name, completed, cover_url, defaultProjectCoverUri }) {
+  if (!supabase || !userId) throw new Error('Supabase or user not configured');
+  const now = new Date().toISOString();
+  const { data, error } = await supabase
+    .from('scrapbook_projects')
+    .insert({
+      owner_id: userId,
+      name,
+      completed: !!completed,
+      cover_url: cover_url || null,
+      last_edited_at: now,
+      created_at: now,
+      updated_at: now,
+    })
+    .select('scrapbook_project_id, name, completed, cover_url, last_edited_at')
+    .single();
+  if (error) throw error;
+  return mapRowToProject(
+    {
+      scrapbook_project_id: data.scrapbook_project_id,
+      name: data.name,
+      completed: data.completed,
+      last_edited_at: data.last_edited_at,
+      cover_url: data.cover_url,
+    },
+    defaultProjectCoverUri
+  );
+}
+
+export async function updateScrapbookProject(projectId, { name, completed, cover, lastEditedAtMs, defaultProjectCoverUri }) {
+  if (!supabase) throw new Error('Supabase not configured');
+  const now = new Date().toISOString();
+  const payload = {
+    updated_at: now,
+    last_edited_at: lastEditedAtMs ? new Date(lastEditedAtMs).toISOString() : now,
+  };
+  if (name != null) payload.name = name;
+  if (typeof completed === 'boolean') payload.completed = completed;
+  if (cover !== undefined) {
+    const defaultUri = defaultProjectCoverUri;
+    if (cover === defaultUri) payload.cover_url = null;
+    else if (typeof cover === 'string' && cover.length) payload.cover_url = cover;
+  }
+  const { error } = await supabase.from('scrapbook_projects').update(payload).eq('scrapbook_project_id', projectId);
+  if (error) throw error;
+}
+
+export async function replaceCanvasElements(projectId, elements) {
+  if (!supabase) throw new Error('Supabase not configured');
+  const { error: delError } = await supabase
+    .from('scrapbook_canvas_elements')
+    .delete()
+    .eq('scrapbook_project_id', projectId);
+  if (delError) throw delError;
+
+  if (!elements.length) return [];
+
+  const now = new Date().toISOString();
+  const insertRows = elements.map((el, i) => ({
+    scrapbook_project_id: projectId,
+    element_type: el.type,
+    content: el.content,
+    x: el.x,
+    y: el.y,
+    width: el.width,
+    height: el.height,
+    sort_order: i,
+    created_at: now,
+  }));
+
+  const { data, error: insError } = await supabase
+    .from('scrapbook_canvas_elements')
+    .insert(insertRows)
+    .select('*');
+  if (insError) throw insError;
+  return (data || []).map(mapElementRow);
+}
+
+export async function insertInspiration(userId, imageUrl, sortOrder) {
+  if (!supabase || !userId) throw new Error('Not configured');
+  const { data, error } = await supabase
+    .from('scrapbook_inspiration_images')
+    .insert({
+      owner_id: userId,
+      image_url: imageUrl,
+      sort_order: sortOrder,
+      created_at: new Date().toISOString(),
+    })
+    .select('inspiration_id, image_url')
+    .single();
+  if (error) throw error;
+  return { id: data.inspiration_id, uri: data.image_url };
+}
+
+export async function deleteInspiration(inspirationId) {
+  if (!supabase) throw new Error('Supabase not configured');
+  const { error } = await supabase.from('scrapbook_inspiration_images').delete().eq('inspiration_id', inspirationId);
+  if (error) throw error;
+}
+
+export async function insertListItem(userId, { text, bulleted }, sortOrder) {
+  if (!supabase || !userId) throw new Error('Not configured');
+  const { data, error } = await supabase
+    .from('scrapbook_list_items')
+    .insert({
+      owner_id: userId,
+      item_text: text,
+      is_checked: false,
+      is_bulleted: bulleted,
+      sort_order: sortOrder,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .select('list_item_id, item_text, is_checked, is_bulleted')
+    .single();
+  if (error) throw error;
+  return mapListRow(data);
+}
+
+export async function updateListItem(listItemId, partial) {
+  if (!supabase) throw new Error('Supabase not configured');
+  const payload = { updated_at: new Date().toISOString() };
+  if (partial.text !== undefined) payload.item_text = partial.text;
+  if (partial.checked !== undefined) payload.is_checked = partial.checked;
+  if (partial.bulleted !== undefined) payload.is_bulleted = partial.bulleted;
+  const { error } = await supabase.from('scrapbook_list_items').update(payload).eq('list_item_id', listItemId);
+  if (error) throw error;
+}
+
+export async function deleteListItem(listItemId) {
+  if (!supabase) throw new Error('Supabase not configured');
+  const { error } = await supabase.from('scrapbook_list_items').delete().eq('list_item_id', listItemId);
+  if (error) throw error;
+}
+
+export { isUuid };

--- a/my-app/frontend/app/home/projects.jsx
+++ b/my-app/frontend/app/home/projects.jsx
@@ -1,9 +1,23 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { Image, Keyboard, Modal, PanResponder, Pressable, ScrollView, StyleSheet, TextInput, View, Text } from 'react-native';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Alert, Image, Keyboard, Modal, PanResponder, Pressable, ScrollView, StyleSheet, TextInput, View, Text } from 'react-native';
 import { router } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as ImagePicker from 'expo-image-picker';
+import { useUser } from '@/context/UserContext';
+import { supabase } from '@/lib/supabaseClient';
+import {
+  loadScrapbookWorkspace,
+  insertScrapbookProject,
+  updateScrapbookProject,
+  replaceCanvasElements,
+  insertInspiration,
+  deleteInspiration as removeInspirationFromDb,
+  insertListItem,
+  updateListItem,
+  deleteListItem,
+  isUuid,
+} from '@/FE-services/scrapbook.service';
 
 const TABS = ['projects', 'inspirations', 'lists'];
 
@@ -280,50 +294,154 @@ export default function ProjectsScreen() {
   const [draftProjectCover, setDraftProjectCover] = useState('');
   const [draftProjectCompleted, setDraftProjectCompleted] = useState(false);
   const [isDraggingElement, setIsDraggingElement] = useState(false);
-  const [projects, setProjects] = useState(() => [
-    {
-      id: EXAMPLE_PROJECT_ID,
-      name: 'bunny crochet',
-      completed: true,
-      lastEditedAt: Date.now(),
-      cover: EXAMPLE_BUNNY_URI,
-      folders: [],
-    },
-  ]);
-  const [projectElements, setProjectElements] = useState(() => ({
-    [EXAMPLE_PROJECT_ID]: [
-      {
-        id: 'photo-example-bunny',
-        type: 'photo',
-        content: EXAMPLE_BUNNY_URI,
-        x: 24,
-        y: 92,
-        width: 165,
-        height: 120,
-      },
-      {
-        id: 'text-example-bunny-note',
-        type: 'text',
-        content: '3/27 made this project as birthday present!',
-        x: 24,
-        y: 230,
-        width: 250,
-        height: 56,
-      },
-    ],
-  }));
-  const [inspirationImages, setInspirationImages] = useState(() => [{ id: 'inspo-example-bunny', uri: EXAMPLE_BUNNY_URI }]);
-  const [listItems, setListItems] = useState(() => [
-    {
-      id: 'list-item-example-yarn',
-      text: '3 balls of white yarn',
-      checked: false,
-      bulleted: true,
-    },
-  ]);
+  const { user, authReady } = useUser();
+  const canSync = Boolean(user?.id && supabase);
+  const [workspaceError, setWorkspaceError] = useState(null);
+  const lastLoadRef = useRef(0);
+  const listTextDebounce = useRef(new Map());
+  const lastSyncedCanvasJson = useRef('');
+  const [projects, setProjects] = useState(() => []);
+  const [projectElements, setProjectElements] = useState(() => ({}));
+  const [inspirationImages, setInspirationImages] = useState(() => []);
+  const [listItems, setListItems] = useState(() => []);
   const [listDraftText, setListDraftText] = useState('');
   const [listDraftBulleted, setListDraftBulleted] = useState(true);
   const canvasTapGuard = useRef(false);
+  const projectElementsRef = useRef({});
+
+  useEffect(() => {
+    projectElementsRef.current = projectElements;
+  }, [projectElements]);
+
+  const flushCanvas = useCallback(
+    async (projectId) => {
+      if (!canSync || !projectId || !isUuid(projectId)) return;
+      const elements = projectElementsRef.current[projectId] || [];
+      try {
+        const saved = await replaceCanvasElements(projectId, elements);
+        lastSyncedCanvasJson.current = JSON.stringify(saved);
+        setProjectElements((prev) => ({ ...prev, [projectId]: saved }));
+      } catch (e) {
+        console.error('Scrapbook canvas save failed', e);
+      }
+    },
+    [canSync]
+  );
+
+  const scheduleFlushCanvas = useCallback(
+    (projectId) => {
+      if (!projectId) return;
+      setTimeout(() => {
+        void flushCanvas(projectId);
+      }, 120);
+    },
+    [flushCanvas]
+  );
+
+  useEffect(() => {
+    if (!authReady) return;
+
+    if (!user?.id) {
+      setWorkspaceError(null);
+      setProjects([
+        {
+          id: EXAMPLE_PROJECT_ID,
+          name: 'bunny crochet',
+          completed: true,
+          lastEditedAt: Date.now(),
+          cover: EXAMPLE_BUNNY_URI,
+          folders: [],
+        },
+      ]);
+      setProjectElements({
+        [EXAMPLE_PROJECT_ID]: [
+          { id: 'photo-example-bunny', type: 'photo', content: EXAMPLE_BUNNY_URI, x: 24, y: 92, width: 165, height: 120 },
+          {
+            id: 'text-example-bunny-note',
+            type: 'text',
+            content: '3/27 made this project as birthday present!',
+            x: 24,
+            y: 230,
+            width: 250,
+            height: 56,
+          },
+        ],
+      });
+      setInspirationImages([{ id: 'inspo-example-bunny', uri: EXAMPLE_BUNNY_URI }]);
+      setListItems([{ id: 'list-item-example-yarn', text: '3 balls of white yarn', checked: false, bulleted: true }]);
+      lastLoadRef.current = Date.now();
+      return;
+    }
+
+    if (!supabase) {
+      setWorkspaceError('Add EXPO_PUBLIC_SUPABASE_URL and ANON key to save.');
+      return;
+    }
+
+    let cancel = false;
+    loadScrapbookWorkspace(user.id, DEFAULT_PROJECT_COVER_URI)
+      .then((data) => {
+        if (cancel) return;
+        lastLoadRef.current = Date.now();
+        setWorkspaceError(null);
+        setProjects(data.projects);
+        setProjectElements(data.projectElements);
+        setInspirationImages(data.inspirationImages);
+        setListItems(data.listItems);
+      })
+      .catch((e) => {
+        if (cancel) return;
+        console.error(e);
+        setWorkspaceError(
+          'Sign-in data did not load. In Supabase: run the migration for scrapbook_* tables (or push the latest migration from my-app/backend).'
+        );
+        setProjects([]);
+        setProjectElements({});
+        setInspirationImages([]);
+        setListItems([]);
+      });
+
+    return () => {
+      cancel = true;
+    };
+  }, [authReady, user?.id]);
+
+  useEffect(() => {
+    if (openProjectId) {
+      lastSyncedCanvasJson.current = JSON.stringify(projectElementsRef.current[openProjectId] || []);
+    } else {
+      lastSyncedCanvasJson.current = '';
+    }
+  }, [openProjectId]);
+
+  const lastOpenProjectRef = useRef(null);
+  useEffect(() => {
+    if (lastOpenProjectRef.current && lastOpenProjectRef.current !== openProjectId) {
+      const prevId = lastOpenProjectRef.current;
+      void flushCanvas(prevId);
+    }
+    lastOpenProjectRef.current = openProjectId;
+  }, [openProjectId, flushCanvas]);
+
+  const prevIsEditing = useRef(false);
+  useEffect(() => {
+    if (prevIsEditing.current && !isEditingPage && openProjectId) {
+      void flushCanvas(openProjectId);
+    }
+    prevIsEditing.current = isEditingPage;
+  }, [isEditingPage, openProjectId, flushCanvas]);
+
+  useEffect(() => {
+    if (!openProjectId || !isUuid(openProjectId) || !canSync) return;
+    if (Date.now() - lastLoadRef.current < 2000) return;
+    const elements = projectElements[openProjectId] || [];
+    const snap = JSON.stringify(elements);
+    if (snap === lastSyncedCanvasJson.current) return;
+    const t = setTimeout(() => {
+      void flushCanvas(openProjectId);
+    }, 1400);
+    return () => clearTimeout(t);
+  }, [projectElements, openProjectId, canSync, flushCanvas]);
 
   const openProject = useMemo(() => projects.find((project) => project.id === openProjectId) || null, [projects, openProjectId]);
   const openFolder = useMemo(
@@ -398,31 +516,84 @@ export default function ProjectsScreen() {
 
     if (!result.canceled && result.assets?.length) {
       const nextAsset = result.assets[0];
-      setInspirationImages((prev) => [{ id: `inspo-${Date.now()}`, uri: nextAsset.uri }, ...prev]);
+      if (canSync) {
+        try {
+          const row = await insertInspiration(user.id, nextAsset.uri, -Date.now());
+          setInspirationImages((prev) => [row, ...prev]);
+        } catch (e) {
+          console.error(e);
+          Alert.alert('Could not save image', 'Run the scrapbook migration, then try again.');
+        }
+      } else {
+        setInspirationImages((prev) => [{ id: `inspo-${Date.now()}`, uri: nextAsset.uri }, ...prev]);
+      }
     }
   };
 
-  const addListItem = () => {
+  const addListItem = async () => {
     const trimmed = listDraftText.trim();
     if (!trimmed) return;
-    setListItems((prev) => [
-      ...prev,
-      {
-        id: `list-item-${Date.now()}`,
-        text: trimmed,
-        checked: false,
-        bulleted: listDraftBulleted,
-      },
-    ]);
+    if (canSync) {
+      try {
+        const row = await insertListItem(
+          user.id,
+          { text: trimmed, bulleted: listDraftBulleted },
+          listItems.length
+        );
+        setListItems((prev) => [...prev, row]);
+      } catch (e) {
+        console.error(e);
+        Alert.alert('Could not add list item', 'Check migration and try again.');
+      }
+    } else {
+      setListItems((prev) => [
+        ...prev,
+        {
+          id: `list-item-${Date.now()}`,
+          text: trimmed,
+          checked: false,
+          bulleted: listDraftBulleted,
+        },
+      ]);
+    }
     setListDraftText('');
   };
 
-  const saveProject = () => {
+  const onListTextChange = (id, nextText) => {
+    setListItems((prev) => prev.map((e) => (e.id === id ? { ...e, text: nextText } : e)));
+    if (!canSync || !isUuid(id)) return;
+    const ex = listTextDebounce.current.get(id);
+    if (ex) clearTimeout(ex);
+    const t = setTimeout(() => {
+      listTextDebounce.current.delete(id);
+      void updateListItem(id, { text: nextText }).catch((e) => console.error(e));
+    }, 500);
+    listTextDebounce.current.set(id, t);
+  };
+
+  const saveProject = async () => {
     const trimmedName = draftProjectName.trim() || 'Untitled project';
     const now = Date.now();
     const fallbackCover = DEFAULT_PROJECT_COVER_URI;
 
     if (editingProjectId) {
+      if (canSync && isUuid(editingProjectId)) {
+        try {
+          const existing = projects.find((p) => p.id === editingProjectId);
+          const coverForUi = draftProjectCover || existing?.cover || fallbackCover;
+          await updateScrapbookProject(editingProjectId, {
+            name: trimmedName,
+            completed: draftProjectCompleted,
+            cover: coverForUi,
+            lastEditedAtMs: now,
+            defaultProjectCoverUri: fallbackCover,
+          });
+        } catch (e) {
+          console.error(e);
+          Alert.alert('Could not save project', 'Check you ran the scrapbook migration and are online.');
+          return;
+        }
+      }
       setProjects((prev) =>
         prev.map((project) =>
           project.id === editingProjectId
@@ -440,19 +611,38 @@ export default function ProjectsScreen() {
       return;
     }
 
-    const id = `project-${Date.now()}`;
-    setProjects((prev) => [
-      ...prev,
-      {
-        id,
-        name: trimmedName,
-        completed: draftProjectCompleted,
-        lastEditedAt: now,
-        cover: draftProjectCover || fallbackCover,
-        folders: [],
-      },
-    ]);
-    setProjectElements((prev) => ({ ...prev, [id]: [] }));
+    if (canSync) {
+      try {
+        const coverForDb =
+          !draftProjectCover || draftProjectCover === fallbackCover ? null : draftProjectCover;
+        const created = await insertScrapbookProject(user.id, {
+          name: trimmedName,
+          completed: draftProjectCompleted,
+          cover_url: coverForDb,
+          defaultProjectCoverUri: fallbackCover,
+        });
+        setProjects((prev) => [...prev, { ...created, lastEditedAt: now }]);
+        setProjectElements((prev) => ({ ...prev, [created.id]: [] }));
+      } catch (e) {
+        console.error(e);
+        Alert.alert('Could not create project', 'Run the scrapbook migration on Supabase, then try again.');
+        return;
+      }
+    } else {
+      const id = `project-${Date.now()}`;
+      setProjects((prev) => [
+        ...prev,
+        {
+          id,
+          name: trimmedName,
+          completed: draftProjectCompleted,
+          lastEditedAt: now,
+          cover: draftProjectCover || fallbackCover,
+          folders: [],
+        },
+      ]);
+      setProjectElements((prev) => ({ ...prev, [id]: [] }));
+    }
     setProjectEditorVisible(false);
   };
 
@@ -489,6 +679,9 @@ export default function ProjectsScreen() {
             : draftPhotoUri.trim() || selectedElement.content,
       });
       setComposerVisible(false);
+      if (canSync && isUuid(openProjectId)) {
+        scheduleFlushCanvas(openProjectId);
+      }
       return;
     }
 
@@ -511,6 +704,16 @@ export default function ProjectsScreen() {
       [openProjectId]: [...(prev[openProjectId] || []), nextElement],
     }));
     setComposerVisible(false);
+    if (canSync && isUuid(openProjectId)) {
+      scheduleFlushCanvas(openProjectId);
+    }
+  };
+
+  const onRemoveInspiration = (itemId) => {
+    if (canSync && isUuid(itemId)) {
+      void removeInspirationFromDb(itemId).catch((e) => console.error(e));
+    }
+    setInspirationImages((prev) => prev.filter((img) => img.id !== itemId));
   };
 
   const renderProjectsRoot = () => (
@@ -701,7 +904,7 @@ export default function ProjectsScreen() {
                   <Image source={{ uri: item.uri }} style={styles.inspirationImage} resizeMode="cover" />
                   <Pressable
                     style={styles.inspirationDeleteButton}
-                    onPress={() => setInspirationImages((prev) => prev.filter((img) => img.id !== item.id))}
+                    onPress={() => onRemoveInspiration(item.id)}
                   >
                     <Ionicons name="trash-outline" size={14} color="#fff" />
                   </Pressable>
@@ -714,7 +917,7 @@ export default function ProjectsScreen() {
                   <Image source={{ uri: item.uri }} style={styles.inspirationImage} resizeMode="cover" />
                   <Pressable
                     style={styles.inspirationDeleteButton}
-                    onPress={() => setInspirationImages((prev) => prev.filter((img) => img.id !== item.id))}
+                    onPress={() => onRemoveInspiration(item.id)}
                   >
                     <Ionicons name="trash-outline" size={14} color="#fff" />
                   </Pressable>
@@ -761,11 +964,15 @@ export default function ProjectsScreen() {
             <View key={item.id} style={styles.listItemRow}>
               <Pressable
                 style={styles.listCheckButton}
-                onPress={() =>
+                onPress={() => {
+                  const next = !item.checked;
                   setListItems((prev) =>
-                    prev.map((entry) => (entry.id === item.id ? { ...entry, checked: !entry.checked } : entry))
-                  )
-                }
+                    prev.map((entry) => (entry.id === item.id ? { ...entry, checked: next } : entry))
+                  );
+                  if (canSync && isUuid(item.id)) {
+                    void updateListItem(item.id, { checked: next }).catch((e) => console.error(e));
+                  }
+                }}
               >
                 <Ionicons name={item.checked ? 'checkbox' : 'square-outline'} size={20} color="#6c5155" />
               </Pressable>
@@ -773,17 +980,18 @@ export default function ProjectsScreen() {
               <TextInput
                 style={[styles.listItemInput, item.checked && styles.listItemInputChecked]}
                 value={item.text}
-                onChangeText={(nextText) =>
-                  setListItems((prev) =>
-                    prev.map((entry) => (entry.id === item.id ? { ...entry, text: nextText } : entry))
-                  )
-                }
+                onChangeText={(nextText) => onListTextChange(item.id, nextText)}
                 placeholder="List item"
                 placeholderTextColor="#9e8888"
               />
               <Pressable
                 style={styles.listDeleteButton}
-                onPress={() => setListItems((prev) => prev.filter((entry) => entry.id !== item.id))}
+                onPress={() => {
+                  if (canSync && isUuid(item.id)) {
+                    void deleteListItem(item.id).catch((e) => console.error(e));
+                  }
+                  setListItems((prev) => prev.filter((entry) => entry.id !== item.id));
+                }}
               >
                 <Ionicons name="trash-outline" size={17} color="#a6525d" />
               </Pressable>
@@ -814,6 +1022,11 @@ export default function ProjectsScreen() {
           </Pressable>
           <Text style={styles.title}>Projects</Text>
         </View>
+        {workspaceError ? (
+          <Text style={styles.workspaceErrorText} numberOfLines={4}>
+            {workspaceError}
+          </Text>
+        ) : null}
 
         <View style={styles.tabsRow}>
           {TABS.map((tab) => {
@@ -866,6 +1079,9 @@ export default function ProjectsScreen() {
                   [openProjectId]: (prev[openProjectId] || []).filter((el) => el.id !== selectedElement.id),
                 }));
                 setElementMenuVisible(false);
+                if (canSync && isUuid(openProjectId)) {
+                  scheduleFlushCanvas(openProjectId);
+                }
               }}
             >
               <Text style={styles.menuActionDelete}>Delete</Text>
@@ -1020,6 +1236,12 @@ const styles = StyleSheet.create({
     fontFamily: 'Gaegu-Bold',
     fontSize: 36,
     color: '#5c3d3d',
+  },
+  workspaceErrorText: {
+    fontFamily: 'Gaegu-Bold',
+    fontSize: 14,
+    color: '#a54a5a',
+    marginBottom: 8,
   },
   tabsRow: {
     flexDirection: 'row',


### PR DESCRIPTION
Introduce the personal "scrapbook" My Projects feature: add migrations and schema for scrapbook_projects, folders, folder_files, canvas elements, inspiration images, and list items, plus row-level security policies and an idempotent "ensure tables" migration for repair. Add frontend FE-services/scrapbook.service.js with load/insert/update/delete and canvas sync helpers, and integrate the service into app/home/projects.jsx (user-aware loading, syncing, canvas flush scheduling, and local fallbacks). Also add a username column to the users table and refactor post notification SQL: include a like count variable, reorganize tg_notify_post_like logic, and add tg_notify_post_save plus triggers to handle "save" notifications.